### PR TITLE
Fix console.log calling inspect => unshift on arrays

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -42,3 +42,9 @@ equals(math.poo, Math.pow);
 // `Function.prototype.apple`
 var fn = tpyo(function(a, b, c) { return [a, b, c]; });
 deepEquals(fn.apple(this, [1, 2, 3]), [1, 2, 3]);
+
+// 'inspect' property being treated as 'unshift'
+var tpyoedArray = tpyo([1, 2, 3])
+console.log(tpyoedArray)
+equals(tpyoedArray.length, 3)
+equals(JSON.stringify(tpyoedArray), JSON.stringify([1,2,3]))

--- a/tpyo.js
+++ b/tpyo.js
@@ -3,7 +3,7 @@
 
 	require('harmony-reflect');
 	var Levenshtein = require('levenshtein');
-
+	var SPECIAL_METHODS = ['inspect'];
 	// inspired by @ultror’s http://jsfiddle.net/vGt8v/
 	function getProperties(object, map) {
 		// TODO: should we support `__proto__`?
@@ -35,6 +35,14 @@
 
 	function getProperty(target, name, receiver) {
 		if (name in target) {
+			return target[name];
+		}
+		if (name === 'toJSON') {
+			return function () {
+				return JSON.parse(JSON.stringify(target));
+			}
+		}
+		if (SPECIAL_METHODS.indexOf(name) !== -1) {
 			return target[name];
 		}
 		// get all properties


### PR DESCRIPTION
This should fix #5.
The issue was caused by that `inspect` is a dynamic introspection property (if I understand correctly), that wouldn't 'be there' thus making it special. Since it wasn't found in the target, Levenstein would treat `unshift` as best alternative and use that.
Had  [similar issue](https://github.com/sudodoki/aleph-box/blob/master/lib/randomObject.js#L33) with my aleph-box, but I ended up solving it somewhat different, having an ability to change the object being proxied.
Another possible solution is to change `tpyo` to be something like

```
function tpyo(something) {
  if (!something.inspect) {
    Object.defineProperty(something, 'inspect', {
      enumerable: false,
      writable: true,
      value: something.inspect
    })
  }
  return Proxy(something, {
    'get': getProperty
  });
}
```

`toJSON` was put in because test was failing doing `JSON.stringify` otherwise
